### PR TITLE
(GH-102 GH-108)Switch to using VS2019 for build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,24 @@
+version: '{build}'
+branches:
+  only:
+  - master
+  - net-standard-migration
+image: Visual Studio 2019
+build_script:
+- ps: >-
+    cd build
+
+    ./build.ps1
+test_script:
+- ps: >-
+    cd ..\working\sources\src\MagicChunks.Tests
+
+
+    dotnet xunit
+artifacts:
+- path: working/dotnet/**/*.zip
+  name: dotnet
+- path: working/nuget/*.nupkg
+  name: nuget
+- path: working/vsts/**/*.vsix
+  name: vsts

--- a/build/build.cake
+++ b/build/build.cake
@@ -155,7 +155,7 @@ Task("Build")
     .Does(() => {
         MSBuild(paths.workingDirSolutionPath, new MSBuildSettings {
             Verbosity = Verbosity.Minimal,
-            ToolVersion = MSBuildToolVersion.VS2017,
+            ToolVersion = MSBuildToolVersion.VS2019,
             Configuration = configuration,
             PlatformTarget = PlatformTarget.MSIL,
         }.WithTarget("Build"));

--- a/src/MagicChunks.Tests/MagicChunks.Tests.csproj
+++ b/src/MagicChunks.Tests/MagicChunks.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <RuntimeFrameworkVersion>2.0.3</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>2.0.9</RuntimeFrameworkVersion>
     <Authors>Sergey Zwezdin</Authors>
     <Company />
     <Product>Magic Chunks</Product>


### PR DESCRIPTION
To allow this to happen, it was easier to introduce an AppVeyor yaml file, to control what VS Base image is used.

Fixes #102 and #108