### PR TITLE
(GH-103) Update to use license expression

### DIFF
--- a/nuspecs/MagicChunks.nuspec
+++ b/nuspecs/MagicChunks.nuspec
@@ -6,7 +6,7 @@
         <title>Magic Chunks</title>
         <authors>Sergey Zwezdin</authors>
         <owners>Sergey Zwezdin</owners>
-        <licenseUrl>https://raw.githubusercontent.com/magic-chunks/magic-chunks-dotnetcore/master/LICENSE</licenseUrl>
+        <license type="expression">MIT</license>
         <projectUrl>https://github.com/magic-chunks/magic-chunks-dotnetcore</projectUrl>
         <iconUrl>https://raw.githubusercontent.com/magic-chunks/magic-chunks-dotnetcore/master/logo/logo64.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/src/MagicChunks.Cake/MagicChunks.Cake.csproj
+++ b/src/MagicChunks.Cake/MagicChunks.Cake.csproj
@@ -7,7 +7,7 @@
     <Product>Magic Chunks</Product>
     <Description>Easy to use tool to config transformations for JSON, XML and YAML.</Description>
     <Copyright>(c) Sergey Zwezdin, 2017</Copyright>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/magic-chunks/magic-chunks-dotnetcore/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/magic-chunks/magic-chunks-dotnetcore</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/magic-chunks/magic-chunks-dotnetcore/master/logo/logo64.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/magic-chunks/magic-chunks-dotnetcore</RepositoryUrl>

--- a/src/MagicChunks.Tests/MagicChunks.Tests.csproj
+++ b/src/MagicChunks.Tests/MagicChunks.Tests.csproj
@@ -8,7 +8,7 @@
     <Product>Magic Chunks</Product>
     <Description>Easy to use tool to config transformations for JSON, XML and YAML.</Description>
     <Copyright>(c) Sergey Zwezdin, 2017</Copyright>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/magic-chunks/magic-chunks-dotnetcore/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/magic-chunks/magic-chunks-dotnetcore</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/magic-chunks/magic-chunks-dotnetcore/master/logo/logo64.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/magic-chunks/magic-chunks-dotnetcore</RepositoryUrl>

--- a/src/MagicChunks/MagicChunks.csproj
+++ b/src/MagicChunks/MagicChunks.csproj
@@ -8,7 +8,7 @@
     <Product>Magic Chunks</Product>
     <Description>Easy to use tool to config transformations for JSON, XML and YAML.</Description>
     <Copyright>(c) Sergey Zwezdin, 2017</Copyright>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/magic-chunks/magic-chunks-dotnetcore/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/magic-chunks/magic-chunks-dotnetcore</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/magic-chunks/magic-chunks-dotnetcore/master/logo/logo64.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/magic-chunks/magic-chunks-dotnetcore</RepositoryUrl>


### PR DESCRIPTION
NuGet Pack was giving warnings about usage of licenseUrl.

Fixes #103 