### PR TITLE
(GH-105) Add respository info to nuspec

### DIFF
--- a/nuspecs/MagicChunks.nuspec
+++ b/nuspecs/MagicChunks.nuspec
@@ -7,6 +7,7 @@
         <authors>Sergey Zwezdin</authors>
         <owners>Sergey Zwezdin</owners>
         <license type="expression">MIT</license>
+        <repository type="git" url="https://github.com/magic-chunks/magic-chunks-dotnetcore.git"/>
         <projectUrl>https://github.com/magic-chunks/magic-chunks-dotnetcore</projectUrl>
         <iconUrl>https://raw.githubusercontent.com/magic-chunks/magic-chunks-dotnetcore/master/logo/logo64.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
This was already in place in the csproj files, this just brings it to
the nupkg as well.

Fixes #105 