### PR TITLE
(GH-104) Switch to using embedded icon

### DIFF
--- a/build/build.cake
+++ b/build/build.cake
@@ -194,6 +194,7 @@ Task("PackNuget")
         EnsureDirectoryExists(paths.workingDirNuget + "/netstandard1.6/MagicChunks");
         EnsureDirectoryExists(paths.workingDirNuget + "/netstandard2.0/MagicChunks");
 
+        CopyFile(paths.root + "/logo/logo64.png", paths.workingDirNuget + "/logo64.png");
         CopyFiles(resolveDirectoryPath(paths.workingDirSources + "/nuspecs") + "/*.nuspec", paths.workingDirNuget);
         CopyFiles(paths.workingDirDotNet + "/**/*.*", paths.workingDirNuget + "/netstandard1.3/MagicChunks");
         CopyFiles(paths.workingDirDotNet + "/**/*.*", paths.workingDirNuget + "/netstandard1.6/MagicChunks");

--- a/nuspecs/MagicChunks.nuspec
+++ b/nuspecs/MagicChunks.nuspec
@@ -9,6 +9,7 @@
         <license type="expression">MIT</license>
         <repository type="git" url="https://github.com/magic-chunks/magic-chunks-dotnetcore.git"/>
         <projectUrl>https://github.com/magic-chunks/magic-chunks-dotnetcore</projectUrl>
+        <icon>logo64.png</icon>
         <iconUrl>https://raw.githubusercontent.com/magic-chunks/magic-chunks-dotnetcore/master/logo/logo64.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Easy to use tool to config transformations for JSON, XML and YAML.</description>
@@ -29,5 +30,6 @@
         <file src="netstandard2.0\MagicChunks\MagicChunks.Cake.dll" target="lib\netstandard2.0" />
         <file src="netstandard2.0\MagicChunks\MagicChunks.targets" target="lib\netstandard2.0" />
         <file src="netstandard2.0\MagicChunks\MagicChunks.psm1" target="lib\netstandard2.0" />
+        <file src="logo64.png" target="" />
     </files>
 </package>

--- a/src/MagicChunks.Cake/MagicChunks.Cake.csproj
+++ b/src/MagicChunks.Cake/MagicChunks.Cake.csproj
@@ -9,11 +9,19 @@
     <Copyright>(c) Sergey Zwezdin, 2017</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/magic-chunks/magic-chunks-dotnetcore</PackageProjectUrl>
+    <PackageIcon>logo64.png</PackageIcon>
     <PackageIconUrl>https://raw.githubusercontent.com/magic-chunks/magic-chunks-dotnetcore/master/logo/logo64.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/magic-chunks/magic-chunks-dotnetcore</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <PackageTags>Configuration, Transform, JSON, XML, YAML, YML, web.config, app.config, appsetings.json</PackageTags>
   </PropertyGroup>
+
+  <ItemGroup>
+      <None Include="../../logo/logo64.png">
+          <Pack>True</Pack>
+          <PackagePath></PackagePath>
+      </None>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Cake.Core" Version="0.26.1" />

--- a/src/MagicChunks.Tests/MagicChunks.Tests.csproj
+++ b/src/MagicChunks.Tests/MagicChunks.Tests.csproj
@@ -10,6 +10,7 @@
     <Copyright>(c) Sergey Zwezdin, 2017</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/magic-chunks/magic-chunks-dotnetcore</PackageProjectUrl>
+    <PackageIcon>logo64.png</PackageIcon>
     <PackageIconUrl>https://raw.githubusercontent.com/magic-chunks/magic-chunks-dotnetcore/master/logo/logo64.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/magic-chunks/magic-chunks-dotnetcore</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
@@ -17,6 +18,14 @@
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
+
+  <ItemGroup>
+      <None Include="../../logo/logo64.png">
+          <Pack>True</Pack>
+          <PackagePath></PackagePath>
+      </None>
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />

--- a/src/MagicChunks/MagicChunks.csproj
+++ b/src/MagicChunks/MagicChunks.csproj
@@ -10,11 +10,20 @@
     <Copyright>(c) Sergey Zwezdin, 2017</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/magic-chunks/magic-chunks-dotnetcore</PackageProjectUrl>
+    <PackageIcon>logo64.png</PackageIcon>
     <PackageIconUrl>https://raw.githubusercontent.com/magic-chunks/magic-chunks-dotnetcore/master/logo/logo64.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/magic-chunks/magic-chunks-dotnetcore</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <PackageTags>Configuration, Transform, JSON, XML, YAML, YML, web.config, app.config, appsetings.json</PackageTags>
   </PropertyGroup>
+
+  <ItemGroup>
+      <None Include="../../logo/logo64.png">
+          <Pack>True</Pack>
+          <PackagePath></PackagePath>
+      </None>
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>


### PR DESCRIPTION
As per guidelines from NuGet Team, leaving pakageIconUrl in place for
fallback.

Fixes #104 