### PR TITLE
(GH-106) Add documentation files to NuGet package

### DIFF
--- a/nuspecs/MagicChunks.nuspec
+++ b/nuspecs/MagicChunks.nuspec
@@ -20,16 +20,15 @@
         <dependencies></dependencies>
     </metadata>
     <files>
-        <file src="netstandard1.3\MagicChunks\MagicChunks.dll" target="lib\netstandard1.3" />
-        <file src="netstandard1.3\MagicChunks\MagicChunks.targets" target="lib\netstandard1.3" />
-        <file src="netstandard1.3\MagicChunks\MagicChunks.psm1" target="lib\netstandard1.3" />
-        <file src="netstandard1.6\MagicChunks\MagicChunks.dll" target="lib\netstandard1.6" />
-        <file src="netstandard1.6\MagicChunks\MagicChunks.targets" target="lib\netstandard1.6" />
-        <file src="netstandard1.6\MagicChunks\MagicChunks.psm1" target="lib\netstandard1.6" />
-        <file src="netstandard2.0\MagicChunks\MagicChunks.dll" target="lib\netstandard2.0" />
-        <file src="netstandard2.0\MagicChunks\MagicChunks.Cake.dll" target="lib\netstandard2.0" />
-        <file src="netstandard2.0\MagicChunks\MagicChunks.targets" target="lib\netstandard2.0" />
-        <file src="netstandard2.0\MagicChunks\MagicChunks.psm1" target="lib\netstandard2.0" />
+        <file src="netstandard1.3\MagicChunks\MagicChunks.*" target="lib\netstandard1.3" />
+        <file src="MagicChunks.targets" target="lib\netstandard1.3" />
+        <file src="MagicChunks.psm1" target="lib\netstandard1.3" />
+        <file src="netstandard1.6\MagicChunks\MagicChunks.*" target="lib\netstandard1.6" />
+        <file src="MagicChunks.targets" target="lib\netstandard1.6" />
+        <file src="MagicChunks.psm1" target="lib\netstandard1.6" />
+        <file src="netstandard2.0\MagicChunks\MagicChunks.*" target="lib\netstandard2.0" />
+        <file src="MagicChunks.targets" target="lib\netstandard2.0" />
+        <file src="MagicChunks.psm1" target="lib\netstandard2.0" />
         <file src="logo64.png" target="" />
     </files>
 </package>

--- a/src/MagicChunks.Cake/MagicChunks.Cake.csproj
+++ b/src/MagicChunks.Cake/MagicChunks.Cake.csproj
@@ -14,6 +14,7 @@
     <RepositoryUrl>https://github.com/magic-chunks/magic-chunks-dotnetcore</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <PackageTags>Configuration, Transform, JSON, XML, YAML, YML, web.config, app.config, appsetings.json</PackageTags>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MagicChunks/MagicChunks.csproj
+++ b/src/MagicChunks/MagicChunks.csproj
@@ -15,6 +15,7 @@
     <RepositoryUrl>https://github.com/magic-chunks/magic-chunks-dotnetcore</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <PackageTags>Configuration, Transform, JSON, XML, YAML, YML, web.config, app.config, appsetings.json</PackageTags>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
During this process, we noted that the generated NuGet package didn't
have the correct ILRepack'ed assembly in the correct lib folder.  We
went through all the different CopyFiles, as well as the files section
in the nuspec file to make sure that everything was placed into the
correct location.

Fixes #106 